### PR TITLE
Fix edge case in the jinjor patch where the virtual node may not be all lower-case

### DIFF
--- a/src/Elm/Kernel/VirtualDom.js
+++ b/src/Elm/Kernel/VirtualDom.js
@@ -1358,7 +1358,7 @@ function _VirtualDom_addDomNodesHelp(domNode, vNode, patches, i, low, high, even
 			}
 		}
 		// 4. this is needed for some edge cases
-		if(vKids[j].$ === __2_NODE && (childNodes[k].tagName || "").toLowerCase() !== vKids[j].__tag)
+		if(vKids[j].$ === __2_NODE && (childNodes[k].tagName || "").toLowerCase() !== vKids[j].__tag.toLowerCase())
 		{
 			console.log("WARN 4: redrawing DOM")
 			_VirtualDom_applyPatchRedraw(childNodes[k], vKids[j], eventNode)

--- a/src/Elm/Kernel/VirtualDom.js
+++ b/src/Elm/Kernel/VirtualDom.js
@@ -1358,7 +1358,7 @@ function _VirtualDom_addDomNodesHelp(domNode, vNode, patches, i, low, high, even
 			}
 		}
 		// 4. this is needed for some edge cases
-		if(vKids[j].$ === __2_NODE && (childNodes[k].tagName || "").toLowerCase() !== vKids[j].__tag.toLowerCase())
+		if(vKids[j].$ === __2_NODE && (childNodes[k].tagName || "").toLowerCase() !== (vKids[j].__tag || "").toLowerCase())
 		{
 			console.log("WARN 4: redrawing DOM")
 			_VirtualDom_applyPatchRedraw(childNodes[k], vKids[j], eventNode)


### PR DESCRIPTION
I've run into an issue when I have an `elm-ui` `el` inside a `typed-svg` `foreignObject` that listens to mouse events. Within this scenario, the camelCasedSpelling was being overlooked, triggering a DOM redraw. This would sometimes drop browser events, partially degrading features relying on fast firing events, like mouse-effects.

Here is the sample app I used to reproduce the issue: https://fir-sandbox-2.lamdera.app/elm-ui-svg-issue